### PR TITLE
patch: codons must be capitalized

### DIFF
--- a/genslm/dataset.py
+++ b/genslm/dataset.py
@@ -669,7 +669,7 @@ class SequenceDataset(Dataset):  # type: ignore[type-arg]
 
     @staticmethod
     def group_by_kmer(seq: str, kmer: int) -> str:
-        return " ".join(seq[i : i + kmer] for i in range(0, len(seq), kmer))
+        return " ".join(seq[i : i + kmer] for i in range(0, len(seq), kmer)).upper()
 
     def __len__(self) -> int:
         return len(self.batch_encodings)


### PR DESCRIPTION
codons must be capitalized before being passed to tokenizer otherwise they are tokenized as UNK:0